### PR TITLE
Fix delete functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,17 @@ Create a vApp from varied sources
 
 Details of the create task will be returned.
 
+## undeploy\_vapp($vapp_href)
+
+Given the org HREF, call an undeploy on it.
+
+( Required before calling delete\_vapp )
+
 ## delete\_vapp($vapp\_href)
 
 Given the org HREF, call a delete on it.
+
+( A call to the undeploy method is required before this )
 
 ## get\_vapp($vappid)
 

--- a/examples/delete-a-vapp.pl
+++ b/examples/delete-a-vapp.pl
@@ -2,13 +2,13 @@
 
 =head1 delete-a-vapps.pl
 
-This example script uses the API to offer a list of vApps and to delete the 
+This example script uses the API to offer a list of vApps and to delete the
 user-selected selected vApp.
 
 =head2 Usage
 
   ./list-vapps.pl --username USER --password PASS --orgname ORG --hostname HOST
-  
+
 NB: "System" is the orgname for sysadmin actions and access.
 
 If a value is not provided in the command line, it will be asked for.
@@ -33,7 +33,7 @@ my $ret = GetOptions(
 $hostname = prompt( 'x', 'Hostname of the vCloud Server:', '', '' ) unless length $hostname;
 $username = prompt( 'x', 'Username:', '', undef ) unless length $username;
 $password = prompt( 'p', 'Password:', '', undef ) and print "\n" unless length $password;
-$orgname = prompt( 'x', 'Orgname:', '', 'System' ) unless length $orgname;
+$orgname  = prompt( 'x', 'Orgname:', '', 'System' ) unless length $orgname;
 
 my $vcd = new VMware::vCloud( $hostname, $username, $password, $orgname, { debug => 1 } );
 
@@ -57,6 +57,7 @@ my $num = prompt( 'r', 'Select a vApp to delete: ', 'CTRL-C to EXIT', undef, 0, 
 
 print "Deleting $vapps{$href[$num]}...\n";
 
+$vcd->undeploy_vapp( $href );
 my $ret  = $vcd->delete_vapp( $href[$num] );
 my $task = $ret->{href};
 

--- a/lib/VMware/API/vCloud.pm
+++ b/lib/VMware/API/vCloud.pm
@@ -1291,9 +1291,42 @@ sub template_get_metadata {
     return $self->get( $href . '/metadata' );
 }
 
+=head2 undeploy($url)
+
+As a parameter, this method takes the org HREF of the vApp
+
+It returns a TaskType that may be checked to verify the task status.
+
+=cut
+
+# https://www.vmware.com/support/vcd/doc/rest-api-doc-1.5-html/operations/POST-UndeployVApp.html
+
+sub undeploy {
+    my $self = shift;
+    my $url  = shift;
+    $self->_debug("API: undeploy($url)\n") if $self->{debug};
+
+    $url .= '/action/undeploy';
+    my $xml =
+        '<UndeployVAppParams xmlns="http://www.vmware.com/vcloud/v1.5">
+        <UndeployPowerAction>powerOff</UndeployPowerAction>
+        </UndeployVAppParams>';
+
+    my $ret =
+        eval {
+            $self->post(
+                $url,
+                'application/vnd.vmware.vcloud.undeployVAppParams+xml',
+                $xml
+            );
+        };
+    my $task_href = $ret->[2]->{Tasks}->[0]->{Task}->{task}->{href};
+    return wantarray ? ( $task_href, $ret ) : \( $task_href, $ret );
+}
+
 =head2 vdc_get($vdcid or $vdcurl)
 
-As a parameter, this method thakes the raw numeric id of the virtual data
+As a parameter, this method takes the raw numeric id of the virtual data
 center or the full URL detailed a catalog.
 
 It returns the requested VDC.

--- a/lib/VMware/vCloud.pm
+++ b/lib/VMware/vCloud.pm
@@ -226,9 +226,26 @@ sub create_vapp_from_sources {
         $vdcid, $tmplid );
 }
 
+=head2 undeploy_vapp($vapp_href)
+
+Given the org HREF, call an undeploy on it
+
+Required before delete_vapp
+
+=cut
+
+sub undeploy_vapp {
+    my $self = shift;
+    my $href = shift;
+    $self->purge();    # Clear cache when deleting
+    return $self->{api}->undeploy($href);
+}
+
 =head2 delete_vapp($vapp_href)
 
 Given the org HREF, call a delete on it.
+
+Requires vApp to have undeploy and poweroff called on it first
 
 =cut
 


### PR DESCRIPTION
When attempting to use the delete method, if a vApp has not been undeployed you
will get an error stating that the vApp must be powered off and undeployed
first. The newly added method performs both at once so that you may delete a
given vApp.